### PR TITLE
Async Serialization #Hacktoberfest

### DIFF
--- a/src/Model/FieldType/ArrayField.test.ts
+++ b/src/Model/FieldType/ArrayField.test.ts
@@ -45,11 +45,12 @@ describe("FieldType: ArrayField", () => {
     expect(ArrayField.serialize).to.be.true;
   });
 
-  it("normalizes an array by returning the given value", () => {
+  it("normalizes an array by returning the given value", async () => {
     const randomArray = [
       random.number(),
     ];
 
-    expect(ArrayField.normalize(randomArray)).to.equal(randomArray);
+    const normalizedValue = await ArrayField.normalize(randomArray);
+    expect(normalizedValue).to.equal(randomArray);
   });
 });

--- a/src/Model/FieldType/ArrayField.ts
+++ b/src/Model/FieldType/ArrayField.ts
@@ -6,5 +6,5 @@ export const ArrayField: IFieldType<any[]> = {
   defaultValidationRules: { type: "array" },
   defaultValue: [],
   isValidType: (value) => value == null || isArray(value),
-  normalize: (value) => value,
+  normalize: async (value) => value,
 };

--- a/src/Model/FieldType/BooleanField.test.ts
+++ b/src/Model/FieldType/BooleanField.test.ts
@@ -48,39 +48,39 @@ describe("FieldType: BooleanField", () => {
 
   describe("normalize", () => {
 
-    it(`normalizes string "true" into boolean "true"`, () => {
+    it(`normalizes string "true" into boolean "true"`, async () => {
       const value = "true";
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.true;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.true;
     });
 
-    it(`normalizes string "false" into boolean "false"`, () => {
+    it(`normalizes string "false" into boolean "false"`, async () => {
       const value = "false";
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
     });
 
-    it(`normalizes number "1" into boolean "true"`, () => {
+    it(`normalizes number "1" into boolean "true"`, async () => {
       const value = 1;
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.true;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.true;
     });
 
-    it(`normalizes number "0" into boolean "false"`, () => {
+    it(`normalizes number "0" into boolean "false"`, async () => {
       const value = 0;
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
     });
 
-    it(`normalizes an empty string into boolean "false"`, () => {
+    it(`normalizes an empty string into boolean "false"`, async () => {
       const value = "";
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
     });
 
-    it(`normalizes NaN into boolean "false"`, () => {
+    it(`normalizes NaN into boolean "false"`, async () => {
       const value = NaN;
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.false;
     });
 
-    it(`normalizes a non-empty string into boolean "true"`, () => {
+    it(`normalizes a non-empty string into boolean "true"`, async () => {
       const value = random.word();
-      expect(BooleanField.normalize(value)).to.be.a("boolean").and.to.be.true;
+      expect(await BooleanField.normalize(value)).to.be.a("boolean").and.to.be.true;
     });
 
   });

--- a/src/Model/FieldType/BooleanField.ts
+++ b/src/Model/FieldType/BooleanField.ts
@@ -6,7 +6,7 @@ export const BooleanField: IFieldType<boolean> = {
   defaultValidationRules: { type: "boolean" },
   defaultValue: false,
   isValidType: (value) => value == null || isBoolean(value),
-  normalize: (value: any) => (
+  normalize: async (value: any) => (
     // Boolean("false") returns true, which is not the behavior we want
     value && typeof value === "string" && value.toLowerCase() === "false"
     ? false

--- a/src/Model/FieldType/DateField.test.ts
+++ b/src/Model/FieldType/DateField.test.ts
@@ -45,11 +45,11 @@ describe("FieldType: DateField", () => {
     expect(DateField.isValidType(value)).to.be.false;
   });
 
-  it("transforms a Date into the correct Date string", () => {
+  it("transforms a Date into the correct Date string", async () => {
     const serializedDate = "2018-02-14";
     const date = parse(serializedDate, "YYYY-MM-DD", new Date());
 
-    expect(DateField.transform(date)).to.equal(serializedDate);
+    expect(await DateField.transform(date)).to.equal(serializedDate);
   });
 
   it("should be serialized", () => {
@@ -58,16 +58,16 @@ describe("FieldType: DateField", () => {
 
   describe("normalize", () => {
 
-    it("normalizes a Date string into its corresponding Date object", () => {
+    it("normalizes a Date string into its corresponding Date object", async () => {
       const serializedDate = "2018-02-14";
       const date = parse(serializedDate, "YYYY-MM-DD", new Date());
 
-      expect(DateField.normalize(serializedDate)).to.deep.equal(date);
+      expect(await DateField.normalize(serializedDate)).to.deep.equal(date);
     });
 
-    it("normalizes a Date object by returning the given value", () => {
+    it("normalizes a Date object by returning the given value", async () => {
       const date = new Date();
-      expect(DateField.normalize(date)).to.equal(date);
+      expect(await DateField.normalize(date)).to.equal(date);
     });
 
   });

--- a/src/Model/FieldType/DateField.ts
+++ b/src/Model/FieldType/DateField.ts
@@ -7,8 +7,8 @@ export const DateField: IFieldType<Date> = {
   defaultValidationRules: { datetime: { dateOnly: true } },
   defaultValue: null,
   isValidType: (value) => value == null || isDate(value),
-  transform: (date: Date) => date != null ? format(date, "YYYY-MM-DD") : null,
-  normalize: (value: string | any): Date => (
+  transform: async (date: Date) => date != null ? format(date, "YYYY-MM-DD") : null,
+  normalize: async (value: string | any): Promise<Date> => (
     isDate(value)
       ? value
       : (value != null

--- a/src/Model/FieldType/DateTimeField.test.ts
+++ b/src/Model/FieldType/DateTimeField.test.ts
@@ -44,9 +44,9 @@ describe("FieldType: DateTimeField", () => {
     expect(DateTimeField.isValidType(value)).to.be.false;
   });
 
-  it("transforms a Date into its corresponding ISO string", () => {
+  it("transforms a Date into its corresponding ISO string", async () => {
     const value = new Date();
-    expect(DateTimeField.transform(value)).to.equal(value.toISOString());
+    expect(await DateTimeField.transform(value)).to.equal(value.toISOString());
   });
 
   it("should be serialized", () => {
@@ -55,16 +55,16 @@ describe("FieldType: DateTimeField", () => {
 
   describe("normalize", () => {
 
-    it("normalizes a Date ISO string into its corresponding Date object", () => {
+    it("normalizes a Date ISO string into its corresponding Date object", async () => {
       const date = new Date();
       const value = date.toISOString();
 
-      expect(DateTimeField.normalize(value)).to.deep.equal(date);
+      expect(await DateTimeField.normalize(value)).to.deep.equal(date);
     });
 
-    it("normalizes a Date object by returning the given value", () => {
+    it("normalizes a Date object by returning the given value", async () => {
       const date = new Date();
-      expect(DateTimeField.normalize(date)).to.equal(date);
+      expect(await DateTimeField.normalize(date)).to.equal(date);
     });
 
   });

--- a/src/Model/FieldType/DateTimeField.ts
+++ b/src/Model/FieldType/DateTimeField.ts
@@ -6,8 +6,8 @@ export const DateTimeField: IFieldType<Date> = {
   defaultValidationRules: { datetime: true },
   defaultValue: null,
   isValidType: (value) => value == null || isDate(value),
-  transform: (date: Date) => date != null ? date.toISOString() : null,
-  normalize: (value: string | any): Date => (
+  transform: async (date: Date) => date != null ? date.toISOString() : null,
+  normalize: async (value: string | any): Promise<Date> => (
     isDate(value)
       ? value
       : (value != null

--- a/src/Model/FieldType/EmailField.test.ts
+++ b/src/Model/FieldType/EmailField.test.ts
@@ -45,8 +45,8 @@ describe("FieldType: EmailField", () => {
     expect(EmailField.serialize).to.be.true;
   });
 
-  it("normalizes any value into a string", () => {
+  it("normalizes any value into a string", async () => {
     const randomNumber = random.number();
-    expect(EmailField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
+    expect(await EmailField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
   });
 });

--- a/src/Model/FieldType/EnumField.test.ts
+++ b/src/Model/FieldType/EnumField.test.ts
@@ -55,11 +55,11 @@ describe("FieldType: EnumField", () => {
     expect(EnumField.serialize).to.be.false;
   });
 
-  it("normalizes a value by returning the given value if it exists in the enum", () => {
-    expect(EnumField.normalize("world")).to.equal(TestEnum.world);
+  it("normalizes a value by returning the given value if it exists in the enum", async () => {
+    expect(await EnumField.normalize("world")).to.equal(TestEnum.world);
   });
 
-  it("normalizes a value which does not exist in the enum by returning null", () => {
-    expect(EnumField.normalize("asdf")).to.be.null;
+  it("normalizes a value which does not exist in the enum by returning null", async () => {
+    expect(await EnumField.normalize("asdf")).to.be.null;
   });
 });

--- a/src/Model/FieldType/EnumField.ts
+++ b/src/Model/FieldType/EnumField.ts
@@ -14,6 +14,6 @@ export const createEnumField = (fieldEnum: any): IFieldType<any> => {
     },
     defaultValue: null,
     isValidType: (value) => value == null || includes(fieldEnum, value),
-    normalize: (value) => value in fieldEnum ? fieldEnum[value] : null,
+    normalize: async (value) => value in fieldEnum ? fieldEnum[value] : null,
   };
 };

--- a/src/Model/FieldType/IFieldType.ts
+++ b/src/Model/FieldType/IFieldType.ts
@@ -4,6 +4,6 @@ export interface IFieldType<T = any> {
   defaultValidationRules: any;
   defaultValue: T;
   isValidType(value: T | any): boolean;
-  transform?(value: T): any;
-  normalize(serializedValue: any): T;
+  transform?(value: T): Promise<any>;
+  normalize(serializedValue: any): Promise<T>;
 }

--- a/src/Model/FieldType/NumberField.test.ts
+++ b/src/Model/FieldType/NumberField.test.ts
@@ -43,8 +43,8 @@ describe("FieldType: NumberField", () => {
     expect(NumberField.serialize).to.be.true;
   });
 
-  it("normalizes any value into a number", () => {
+  it("normalizes any value into a number", async () => {
     const value = "7";
-    expect(NumberField.normalize(value)).to.be.a("number").and.to.equal(7);
+    expect(await NumberField.normalize(value)).to.be.a("number").and.to.equal(7);
   });
 });

--- a/src/Model/FieldType/NumberField.ts
+++ b/src/Model/FieldType/NumberField.ts
@@ -6,5 +6,5 @@ export const NumberField: IFieldType<number> = {
   defaultValidationRules: { numericality: true },
   defaultValue: 0,
   isValidType: (value) => value == null || isNumber(value),
-  normalize: (value) => Number(value),
+  normalize: async (value) => Number(value),
 };

--- a/src/Model/FieldType/ObjectField.test.ts
+++ b/src/Model/FieldType/ObjectField.test.ts
@@ -45,11 +45,11 @@ describe("FieldType: ObjectField", () => {
     expect(ObjectField.serialize).to.be.true;
   });
 
-  it("normalizes an object by returning the given value", () => {
+  it("normalizes an object by returning the given value", async () => {
     const randomObject = {
       asdf: random.number(),
     };
 
-    expect(ObjectField.normalize(randomObject)).to.equal(randomObject);
+    expect(await ObjectField.normalize(randomObject)).to.equal(randomObject);
   });
 });

--- a/src/Model/FieldType/ObjectField.ts
+++ b/src/Model/FieldType/ObjectField.ts
@@ -6,5 +6,5 @@ export const ObjectField: IFieldType<object> = {
   defaultValidationRules: { type: "object" },
   defaultValue: null,
   isValidType: value => value == null || isObject(value),
-  normalize: value => value,
+  normalize: async value => value,
 };

--- a/src/Model/FieldType/PhoneNumberField.test.ts
+++ b/src/Model/FieldType/PhoneNumberField.test.ts
@@ -50,8 +50,8 @@ describe("FieldType: PhoneNumberField", () => {
     expect(PhoneNumberField.serialize).to.be.true;
   });
 
-  it("normalizes any value into a string", () => {
+  it("normalizes any value into a string", async () => {
     const randomNumber = random.number();
-    expect(PhoneNumberField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
+    expect(await PhoneNumberField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
   });
 });

--- a/src/Model/FieldType/PhoneNumberField.ts
+++ b/src/Model/FieldType/PhoneNumberField.ts
@@ -6,5 +6,5 @@ export const PhoneNumberField: IFieldType<string> = {
   defaultValidationRules: { phoneNumber: true },
   defaultValue: "",
   isValidType: (value) => value == null || isString(value),
-  normalize: (value) => String(value),
+  normalize: async (value) => String(value),
 };

--- a/src/Model/FieldType/StringField.test.ts
+++ b/src/Model/FieldType/StringField.test.ts
@@ -45,12 +45,12 @@ describe("FieldType: StringField", () => {
     expect(StringField.serialize).to.be.true;
   });
 
-  it("normalizes any value into a string", () => {
+  it("normalizes any value into a string", async () => {
     const randomNumber = random.number();
-    expect(StringField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
+    expect(await StringField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
   });
 
-  it("normalizes any null-like value into an empty string", () => {
-    expect(StringField.normalize(null)).to.be.a("string").and.to.equal("");
+  it("normalizes any null-like value into an empty string", async () => {
+    expect(await StringField.normalize(null)).to.be.a("string").and.to.equal("");
   });
 });

--- a/src/Model/FieldType/StringField.ts
+++ b/src/Model/FieldType/StringField.ts
@@ -6,5 +6,5 @@ export const StringField: IFieldType<string> = {
   defaultValidationRules: { type: "string" },
   defaultValue: "",
   isValidType: (value) => value == null || isString(value),
-  normalize: (value) => value != null ? String(value) : "",
+  normalize: async (value) => value != null ? String(value) : "",
 };

--- a/src/Model/FieldType/TimeField.test.ts
+++ b/src/Model/FieldType/TimeField.test.ts
@@ -46,18 +46,18 @@ describe("FieldType: TimeField", () => {
     expect(TimeField.isValidType(value)).to.be.false;
   });
 
-  it("transforms a Time into the correct Time string", () => {
+  it("transforms a Time into the correct Time string", async () => {
     const serializedDate = "04:20:32 pm";
     const date = parse(serializedDate, "hh:mm:ss a", new Date());
 
-    expect(TimeField.transform(date)).to.equal(serializedDate);
+    expect(await TimeField.transform(date)).to.equal(serializedDate);
   });
 
-  it("normalizes a Time string into its corresponding Date object", () => {
+  it("normalizes a Time string into its corresponding Date object", async () => {
     const serializedDate = "04:20:32 pm";
     const date = parse(serializedDate, "hh:mm:ss a", new Date());
 
-    expect(TimeField.normalize(serializedDate)).to.deep.equal(date);
+    expect(await TimeField.normalize(serializedDate)).to.deep.equal(date);
   });
 
   it("should be serialized", () => {

--- a/src/Model/FieldType/TimeField.ts
+++ b/src/Model/FieldType/TimeField.ts
@@ -7,8 +7,8 @@ export const TimeField: IFieldType<Date> = {
   defaultValidationRules: { datetime: { timeOnly: true, message: "must be a valid time" } },
   defaultValue: null,
   isValidType: (value) => value == null || isDate(value),
-  transform: (date: Date) => date != null ? format(date, "hh:mm:ss a") : null,
-  normalize: (serializedDate: string): Date => (
+  transform: async (date: Date) => date != null ? format(date, "hh:mm:ss a") : null,
+  normalize: async (serializedDate: string): Promise<Date> => (
     serializedDate != null
       ? parse(serializedDate, "hh:mm:ss a", new Date())
       : null

--- a/src/Model/FieldType/URLField.test.ts
+++ b/src/Model/FieldType/URLField.test.ts
@@ -45,8 +45,8 @@ describe("FieldType: URLField", () => {
     expect(URLField.serialize).to.be.true;
   });
 
-  it("normalizes any value into a string", () => {
+  it("normalizes any value into a string", async () => {
     const randomNumber = random.number();
-    expect(URLField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
+    expect(await URLField.normalize(randomNumber)).to.be.a("string").and.to.equal(String(randomNumber));
   });
 });

--- a/src/Model/FieldType/URLField.ts
+++ b/src/Model/FieldType/URLField.ts
@@ -6,5 +6,5 @@ export const URLField: IFieldType<string> = {
   defaultValidationRules: { url: { allowLocal: true } },
   defaultValue: "",
   isValidType: (value) => value == null || isString(value),
-  normalize: (value) => String(value),
+  normalize: async (value) => String(value),
 };

--- a/src/Model/IModel.ts
+++ b/src/Model/IModel.ts
@@ -35,7 +35,7 @@ export interface IModel<T extends IModelData> extends IModelMeta<T>, IModelData,
   applyUpdates(modelData?: Partial<T>, meta?: Partial<IModelMeta<T>>, relationships?: any): IModel<T>;
   initializeNewModel(): void;
   markForDestruction(): void;
-  parseFieldValue(fieldName: string, value: any): any;
+  parseFieldValue(fieldName: string, value: any): Promise<any>;
 }
 
 export interface IModelFactory<T extends IModelData> {

--- a/src/Model/Model.test.ts
+++ b/src/Model/Model.test.ts
@@ -1124,11 +1124,11 @@ describe("Model", () => {
   });
 
   describe("Model#parseFieldValue", () => {
-    it("parses the given value using the specified fieldName", () => {
+    it("parses the given value using the specified fieldName", async () => {
       initializeTestServices(fakeModelModule);
 
       const model = seedService<IFakeModelData>("fakeModel");
-      const value = model.parseFieldValue("fullText", 4);
+      const value = await model.parseFieldValue("fullText", 4);
 
       expect(value).to.be.a("string").and.to.equal("4");
     });

--- a/src/Model/Model.ts
+++ b/src/Model/Model.ts
@@ -634,10 +634,10 @@ export class Model<T extends IModelData> implements IModel<T> {
    * Given a fieldName as a deep path (such as "firstName" or "person.firstName"),
    * this will use that field's own IFieldType.normalize function to parse the given value.
    */
-  public parseFieldValue(fieldName: string, value: any): any {
+  public async parseFieldValue(fieldName: string, value: any): Promise<any> {
     const path = addPenultimateFieldToPath(fieldName, "fields");
     const field: IFieldType<any> = get(this, path);
 
-    return field.normalize(value);
+    return await field.normalize(value);
   }
 }

--- a/src/Serializers/BaseSerializer.test.ts
+++ b/src/Serializers/BaseSerializer.test.ts
@@ -126,8 +126,8 @@ describe("BaseSerializer", () => {
       fakeModel = new MockModel(mockModelData);
     });
 
-    it("transforms the model into a plain javascript object based on each field's FieldType", () => {
-      const transformedModelData = mockSerializer.transform(fakeModel);
+    it("transforms the model into a plain javascript object based on each field's FieldType", async () => {
+      const transformedModelData = await mockSerializer.transform(fakeModel);
 
       expect(transformedModelData).to.deep.equal({
         age,
@@ -139,39 +139,39 @@ describe("BaseSerializer", () => {
       });
     });
 
-    it("excludes transforming fields from the model using the model's fields property", () => {
+    it("excludes transforming fields from the model using the model's fields property", async () => {
       fakeModel.fields.age.serialize = false;
-      const transformedModelData = mockSerializer.transform(fakeModel);
+      const transformedModelData = await mockSerializer.transform(fakeModel);
 
       expect(transformedModelData).to.not.have.property("age");
     });
 
-    it("excludes transforming relationships from the model by default", () => {
-      const transformedModelData = mockSerializer.transform(fakeModel);
+    it("excludes transforming relationships from the model by default", async () => {
+      const transformedModelData = await mockSerializer.transform(fakeModel);
 
       expect(fakeModel).to.have.property("organization");
       expect(transformedModelData).to.not.have.property("organization");
     });
 
-    it("transforms belongsTo relationships on the model when serialize = true", () => {
+    it("transforms belongsTo relationships on the model when serialize = true", async () => {
       stub(fakeRelatedService.serializer, "transform").callThrough();
 
       fakeModel.fields.organization.serialize = true;
-      const transformedModelData = mockSerializer.transform(fakeModel);
+      const transformedModelData = await mockSerializer.transform(fakeModel);
 
       expect(transformedModelData).to.have.property("organization").to.deep.equal(omit(fakeRelatedModelData, "id"));
     });
 
-    it("uses the belongsTo relationship's own data service to transform it when serialize = true", () => {
+    it("uses the belongsTo relationship's own data service to transform it when serialize = true", async () => {
       const stubRelatedSerializerTransform = stub(fakeRelatedService.serializer, "transform").returns(fakeRelatedModelData);
 
       fakeModel.fields.organization.serialize = true;
-      mockSerializer.transform(fakeModel);
+      await mockSerializer.transform(fakeModel);
 
       expect(stubRelatedSerializerTransform.firstCall.args[0]).to.equal(fakeModel.organization);
     });
 
-    it("transforms hasMany relationships on the model when serialize = true", () => {
+    it("transforms hasMany relationships on the model when serialize = true", async () => {
       stub(fakeRelatedService.serializer, "transform").callThrough();
 
       const anotherFakeRelatedModelId = faker.random.number().toString();
@@ -188,7 +188,7 @@ describe("BaseSerializer", () => {
       });
 
       fakeModel.fields.fakeItems.serialize = true;
-      const transformedModelData = mockSerializer.transform(fakeModel);
+      const transformedModelData = await mockSerializer.transform(fakeModel);
 
       expect(transformedModelData).to.have.property("fakeItems").to.deep.equal([
         omit(fakeRelatedModelData, "id"),
@@ -224,7 +224,7 @@ describe("BaseSerializer", () => {
       registerService(fakeRelatedService);
     });
 
-    it("normalizes raw data to create an instance of the model", () => {
+    it("normalizes raw data to create an instance of the model", async () => {
       const age = faker.random.number();
       const fullText = faker.lorem.word();
       const startDateString = format(faker.date.recent(), "YYYY-MM-DD");
@@ -239,7 +239,7 @@ describe("BaseSerializer", () => {
         organizationId: fakeRelatedModelId,
       };
 
-      const model = mockSerializer.normalize(rawModelData);
+      const model = await mockSerializer.normalize(rawModelData);
 
       expect(model).to.deep.contain({
         age,
@@ -278,21 +278,21 @@ describe("BaseSerializer", () => {
         pushRecordStub.restore();
       });
 
-      it("normalizes nested related data", () => {
+      it("normalizes nested related data", async () => {
         const normalizeStub = stub(fakeRelatedService.serializer, "normalize").callThrough();
-        mockSerializer.normalize(rawModelData);
+        await mockSerializer.normalize(rawModelData);
 
         expect(normalizeStub.firstCall.args[0]).to.equal(relatedModelData);
       });
 
-      it("creates a pushRecord action with related data", () => {
-        mockSerializer.normalize(rawModelData);
+      it("creates a pushRecord action with related data", async () => {
+        await mockSerializer.normalize(rawModelData);
 
         expect(pushRecordStub.firstCall.args[0]).to.deep.equal(new FakeRelatedModel(relatedModelData));
       });
 
-      it("invokes a pushRecord action with related data", () => {
-        mockSerializer.normalize(rawModelData);
+      it("invokes a pushRecord action with related data", async () => {
+        await mockSerializer.normalize(rawModelData);
         expect(invokeSpy.calledOnce).to.be.true;
       });
     });
@@ -333,25 +333,25 @@ describe("BaseSerializer", () => {
         pushRecordStub.restore();
       });
 
-      it("normalizes nested related data for each item", () => {
+      it("normalizes nested related data for each item", async () => {
         const normalizeStub = stub(fakeRelatedService.serializer, "normalize").callThrough();
-        mockSerializer.normalize(rawModelData);
+        await mockSerializer.normalize(rawModelData);
 
         relatedModelsData.forEach((itemData, index) => {
           expect(normalizeStub.getCall(index).args[0]).to.equal(itemData);
         });
       });
 
-      it("creates a pushRecord action for each item", () => {
-        mockSerializer.normalize(rawModelData);
+      it("creates a pushRecord action for each item", async () => {
+        await mockSerializer.normalize(rawModelData);
 
         relatedModelsData.forEach((itemData, index) => {
           expect(pushRecordStub.getCall(index).args[0]).to.deep.equal(new FakeRelatedModel(itemData));
         });
       });
 
-      it("invokes a pushRecord action for each item", () => {
-        mockSerializer.normalize(rawModelData);
+      it("invokes a pushRecord action for each item", async () => {
+        await mockSerializer.normalize(rawModelData);
         expect(invokeSpy.callCount).to.equal(relatedModelsData.length);
       });
     });

--- a/src/Serializers/BaseSerializer.ts
+++ b/src/Serializers/BaseSerializer.ts
@@ -19,7 +19,6 @@ export abstract class BaseSerializer<S, T extends IModelData, R = T> implements 
   public readonly ModelClass: IModelFactory<T>;
 
   public abstract async deserialize(data: R): Promise<IModel<T>>;
-
   public abstract async serialize(modelData: IModel<T> | Partial<T>): Promise<S>;
 
   public constructor(ModelClass: IModelFactory<T>) {

--- a/src/Serializers/ISerializer.ts
+++ b/src/Serializers/ISerializer.ts
@@ -1,10 +1,10 @@
 import { IModel, IModelData, IModelFactory } from "../Model";
 
 export interface ISerializer<S, T extends IModelData, R = T> {
-  serialize: (modelData: IModel<T> | Partial<T>) => S;
-  deserialize: (data: R) => IModel<T>;
-  transform: (model: IModel<T>) => Partial<R>;
-  normalize: (data: Partial<R>) => IModel<T>;
+  serialize: (modelData: IModel<T> | Partial<T>) => Promise<S>;
+  deserialize: (data: R) => Promise<IModel<T>>;
+  transform: (model: IModel<T>) => Promise<Partial<R>>;
+  normalize: (data: Partial<R>) => Promise<IModel<T>>;
 }
 
 export interface ISerializerFactory<S, T extends IModelData, R = T> {

--- a/src/Serializers/MemorySerializer.test.ts
+++ b/src/Serializers/MemorySerializer.test.ts
@@ -18,15 +18,15 @@ describe("MemorySerializer", () => {
     serializer = new MemorySerializer(FakeModel);
   });
 
-  it("serialize() returns the raw model data", () => {
+  it("serialize() returns the raw model data", async () => {
     const fakeModel = seedService("fakeModel") as any;
-    expect(serializer.serialize(fakeModel))
+    expect(await serializer.serialize(fakeModel))
       .to.deep.contain(omit(fakeModel.modelData, ["id", "dateUpdated", "dateDeleted"]));
   });
 
-  it("deserialize() returns the model when given raw data", () => {
+  it("deserialize() returns the model when given raw data", async () => {
     const fakeModel = seedService("fakeModel") as any;
-    expect(serializer.deserialize(fakeModel.modelData))
+    expect(await serializer.deserialize(fakeModel.modelData))
       .to.deep.equal(fakeModel);
   });
 

--- a/src/Serializers/MemorySerializer.ts
+++ b/src/Serializers/MemorySerializer.ts
@@ -6,11 +6,11 @@ import { BaseSerializer } from "./BaseSerializer";
  */
 export class MemorySerializer<T extends IModelData, R = T> extends BaseSerializer<Partial<R>, T, R> {
 
-  public serialize(model: IModel<T> | Partial<T>): Partial<R> {
-    return this.transform(model);
+  public async serialize(model: IModel<T> | Partial<T>): Promise<Partial<R>> {
+    return await this.transform(model);
   }
 
-  public deserialize(data: Partial<R>): IModel<T> {
-    return this.normalize(data);
+  public async deserialize(data: Partial<R>): Promise<IModel<T>> {
+    return await this.normalize(data);
   }
 }

--- a/src/Serializers/MockSerializer.ts
+++ b/src/Serializers/MockSerializer.ts
@@ -2,11 +2,11 @@ import { FakeModel } from "../Model/Model.mock";
 import { BaseSerializer } from "./BaseSerializer";
 
 export class MockSerializer extends BaseSerializer<any, any> {
-  public serialize() {
+  public async serialize() {
     return "";
   }
 
-  public deserialize() {
+  public async deserialize() {
     return new FakeModel({ id: "123" });
   }
 }

--- a/src/Serializers/RestSerializer.test.ts
+++ b/src/Serializers/RestSerializer.test.ts
@@ -13,17 +13,17 @@ describe("RestSerializer", () => {
 
   describe("serialize", () => {
 
-    it("first transforms the model before serializing it", () => {
+    it("first transforms the model before serializing it", async () => {
       const fakeModel = new FakeModel({ id: faker.random.number().toString() });
       const restSerializer = new RestSerializer(FakeModel);
       const stubTransform = stub(restSerializer, "transform");
 
-      restSerializer.serialize(fakeModel);
+      await restSerializer.serialize(fakeModel);
 
       expect(stubTransform.firstCall.args[0]).to.equal(fakeModel);
     });
 
-    it("converts the model into a JSON string", () => {
+    it("converts the model into a JSON string", async () => {
       const fullText = faker.lorem.word().toString();
 
       const fakeModel = new FakeModel({
@@ -32,7 +32,7 @@ describe("RestSerializer", () => {
       });
 
       const restSerializer = new RestSerializer(FakeModel);
-      const serializedModel = restSerializer.serialize(fakeModel);
+      const serializedModel = await restSerializer.serialize(fakeModel);
 
       expect(serializedModel).to.equal(JSON.stringify({ fullText }));
     });
@@ -41,7 +41,7 @@ describe("RestSerializer", () => {
 
   describe("deserialize", () => {
 
-    it("converts the deserialized raw data into a Model by normalizing it", () => {
+    it("converts the deserialized raw data into a Model by normalizing it", async () => {
       const fakeModelData = {
         id: faker.random.number().toString(),
         fullText: faker.lorem.word().toString(),
@@ -51,12 +51,12 @@ describe("RestSerializer", () => {
       const restSerializer = new RestSerializer(FakeModel);
       const stubNormalize = stub(restSerializer, "normalize");
 
-      restSerializer.deserialize(serializedModel);
+      await restSerializer.deserialize(serializedModel);
 
       expect(stubNormalize.firstCall.args[0]).to.deep.equal(fakeModelData);
     });
 
-    it("converts the JSON string into a model", () => {
+    it("converts the JSON string into a model", async () => {
       const fakeModelData = {
         id: faker.random.number().toString(),
         fullText: faker.lorem.word().toString(),
@@ -65,7 +65,7 @@ describe("RestSerializer", () => {
       const serializedModel = JSON.stringify(fakeModelData);
       const restSerializer = new RestSerializer(FakeModel);
 
-      const deserializedModel = restSerializer.deserialize(serializedModel);
+      const deserializedModel = await restSerializer.deserialize(serializedModel);
 
       expect(deserializedModel).to.deep.equal(fakeModel);
     });

--- a/src/Serializers/RestSerializer.ts
+++ b/src/Serializers/RestSerializer.ts
@@ -10,10 +10,10 @@ export class RestSerializer<T extends IModelData, R = T> extends BaseSerializer<
    * Converts the given IModel into a JSON string.
    *
    * @param {IModel<T extends IModelData> | Partial<T extends IModelData>} model
-   * @returns {any}
+   * @returns {Promise<S>}
    */
-  public serialize(model: IModel<T> | Partial<T>): string {
-    const modelData = this.transform(model);
+  public async serialize(model: IModel<T> | Partial<T>): Promise<string> {
+    const modelData = await this.transform(model);
     return JSON.stringify(modelData);
   }
 
@@ -22,9 +22,9 @@ export class RestSerializer<T extends IModelData, R = T> extends BaseSerializer<
    *
    * @param {IModel<T extends IModelData>} data
    * @param data
-   * @returns {IModel<T extends IModelData>}
+   * @returns {Promise<IModel<T extends IModelData>>}
    */
-  public deserialize(data: any): IModel<T> {
+  public async deserialize(data: any): Promise<IModel<T>> {
     data = (typeof data === "string") ? JSON.parse(data) : data;
     return this.normalize(data);
   }

--- a/src/Serializers/RestSerializer.ts
+++ b/src/Serializers/RestSerializer.ts
@@ -26,6 +26,6 @@ export class RestSerializer<T extends IModelData, R = T> extends BaseSerializer<
    */
   public async deserialize(data: any): Promise<IModel<T>> {
     data = (typeof data === "string") ? JSON.parse(data) : data;
-    return this.normalize(data);
+    return await this.normalize(data);
   }
 }

--- a/src/Utils/Lodash.ts
+++ b/src/Utils/Lodash.ts
@@ -1,5 +1,5 @@
 import * as convert from "lodash/fp/convert";
-import { mapValues, forEach, isPlainObject } from "lodash";
+import { forEach, isPlainObject, map, mapValues } from "lodash";
 
 /**
  * By default, lodash/fp/mapValues does not return the key to the iterator.
@@ -9,6 +9,17 @@ import { mapValues, forEach, isPlainObject } from "lodash";
  * @see https://github.com/lodash/lodash/wiki/FP-Guide
  */
 export const mapValuesWithKeys = convert("mapValues", mapValues, {
+  cap: false,
+});
+
+/**
+ * By default, lodash/fp/map does not return the key to the iterator.
+ * This example was lifted from their docs to make it work as expected.
+ *
+ * @type {any}
+ * @see https://github.com/lodash/lodash/wiki/FP-Guide
+ */
+export const mapWithKeys = convert("map", map, {
   cap: false,
 });
 


### PR DESCRIPTION
We now have support for serializing a model asynchronously. The redux-observable epics inside of the  Redux service will correctly wait for the serializer to serialize/deserialize the model to/from a plain object before/after making requests to the external REST API, using the RxJS "mergeMap" function and the ES6 async/await syntax.