### PR TITLE
IO-2282 updating model.original to model.original()

### DIFF
--- a/src/Mapper/Mapper.test.ts
+++ b/src/Mapper/Mapper.test.ts
@@ -5,7 +5,7 @@ import { spy, stub } from "sinon";
 
 import { date, lorem, random } from "faker";
 import { format, parse } from "date-fns";
-import { flatten, omit } from "lodash";
+import { omit } from "lodash";
 import * as jiff from "jiff";
 
 import { BaseService, DataService, registerService } from "../Services";
@@ -159,15 +159,7 @@ describe("Mapper", () => {
       beforeEach(() => {
         originalFullText = lorem.slug();
         originalModel = new MockModel({ ...mockModelData, fullText: originalFullText });
-
-        originalModelSpy = spy();
-        Object.defineProperty(fakeModel, "original", {
-          get() {
-            originalModelSpy();
-            return originalModel;
-          },
-          configurable: true,
-        });
+        originalModelSpy = stub(fakeModel, "original").returns(originalModel);
       });
 
       it("calls transform twice", async () => {
@@ -471,7 +463,7 @@ describe("Mapper", () => {
           parentServiceName: "fakeModel",
           serializeThroughParent: true,
         });
-        
+
         expect(pushRecordStub.firstCall.args[0]).to.deep.equal(expectedValue);
       });
 

--- a/src/Mapper/Mapper.ts
+++ b/src/Mapper/Mapper.ts
@@ -83,7 +83,7 @@ export class Mapper<T extends IModelData, R = T> implements IMapper<T, R> {
 
   /** Calls transform on the model and the model.original then creates a JSON patch to update the original to the updated */
   public async transformPatch(model: IModel<T> | Partial<T> | any) {
-    const original = await this.transform(model.original);
+    const original = await this.transform(model.original());
     const updated = await this.transform(model);
 
     return diff(original, updated);


### PR DESCRIPTION
Update transform patch to call model.original as a function rather than a getter